### PR TITLE
Update 2016

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -16,39 +16,39 @@ export default DS.Adapter.extend({
   },
 
   find: function(store, type, id) {
-    return this._send(type.typeKey, "show", {id: id});
+    return this._send(type.modelName, "show", {id: id});
   },
 
   findAll: function(store, type) {
-    return this._send(type.typeKey, "all", {});
+    return this._send(type.modelName, "all", {});
   },
 
   findQuery: function(store, type, query) {
-    return this._send(type.typeKey, "show", query);
+    return this._send(type.modelName, "show", query);
   },
 
   createRecord: function(store, type, snapshot) {
     const data = {};
-    const serializer = store.serializerFor(type.typeKey);
+    const serializer = store.serializerFor(type.modelName);
 
     serializer.serializeIntoHash(data, type, snapshot, { includeId: true });
 
-    return this._send(type.typeKey, "create", data);
+    return this._send(type.modelName, "create", data);
   },
 
   updateRecord: function(store, type, snapshot) {
     const data = {};
-    const serializer = store.serializerFor(type.typeKey);
+    const serializer = store.serializerFor(type.modelName);
 
     serializer.serializeIntoHash(data, type, snapshot);
 
-    return this._send(type.typeKey, "update", data);
+    return this._send(type.modelName, "update", data);
   },
 
   deleteRecord: function(store, type, snapshot) {
     const id = snapshot.id;
 
-    return this._send(type.typeKey, "delete", { id: id });
+    return this._send(type.modelName, "delete", { id: id });
   },
 
   _send: function(type, action, message) {

--- a/addon/index.js
+++ b/addon/index.js
@@ -68,13 +68,14 @@ export default DS.Adapter.extend({
     const joinParams = this.get("joinParams");
     const pluralType = pluralize(type);
 
-    this.phoenix.join(`${pluralType}:${action}`, joinParams).
+    const channel = this.phoenix.channel(`${pluralType}:${action}`, joinParams);
+    channel.join().
       receive("ignore", () => {
         const error = `Could not connect to the ${type} channel`;
         Ember.logger.warn(error);
         reject(error);
       }).
-      receive("ok", (channel) => {
+      receive("ok", (resp) => {
         this._listenToEvents(channel, type);
         this.joinedChannels[type] = channel;
         this._resolvePush(channel.push(action, message), resolve, reject);

--- a/app/initializers/phoenix-adapter.js
+++ b/app/initializers/phoenix-adapter.js
@@ -6,7 +6,7 @@ export default {
   name: "phoenix-adapter",
   after: "store",
 
-  initialize: function(container, application) {
+  initialize: function(application) {
     const uri = ENV.SocketURI;
 
     if (uri === undefined || uri === null) {

--- a/app/phoenix.js
+++ b/app/phoenix.js
@@ -1,4 +1,99 @@
+// Phoenix Channels JavaScript client
+//
+// ## Socket Connection
+//
+// A single connection is established to the server and
+// channels are mulitplexed over the connection.
+// Connect to the server using the `Socket` class:
+//
+//     let socket = new Socket("/ws", {params: {userToken: "123"}})
+//     socket.connect()
+//
+// The `Socket` constructor takes the mount point of the socket,
+// the authentication params, as well as options that can be found in
+// the Socket docs, such as configuring the `LongPoll` transport, and
+// heartbeat.
+//
+// ## Channels
+//
+// Channels are isolated, concurrent processes on the server that
+// subscribe to topics and broker events between the client and server.
+// To join a channel, you must provide the topic, and channel params for
+// authorization. Here's an example chat room example where `"new_msg"`
+// events are listened for, messages are pushed to the server, and
+// the channel is joined with ok/error/timeout matches:
+//
+//     let channel = socket.channel("rooms:123", {token: roomToken})
+//     channel.on("new_msg", msg => console.log("Got message", msg) )
+//     $input.onEnter( e => {
+//       channel.push("new_msg", {body: e.target.val}, 10000)
+//        .receive("ok", (msg) => console.log("created message", msg) )
+//        .receive("error", (reasons) => console.log("create failed", reasons) )
+//        .receive("timeout", () => console.log("Networking issue...") )
+//     })
+//     channel.join()
+//       .receive("ok", ({messages}) => console.log("catching up", messages) )
+//       .receive("error", ({reason}) => console.log("failed join", reason) )
+//       .receive("timeout", () => console.log("Networking issue. Still waiting...") )
+//
+//
+// ## Joining
+//
+// Joining a channel with `channel.join(topic, params)`, binds the params to
+// `channel.params`. Subsequent rejoins will send up the modified params for
+// updating authorization params, or passing up last_message_id information.
+// Successful joins receive an "ok" status, while unsuccessful joins
+// receive "error".
+//
+//
+// ## Pushing Messages
+//
+// From the previous example, we can see that pushing messages to the server
+// can be done with `channel.push(eventName, payload)` and we can optionally
+// receive responses from the push. Additionally, we can use
+// `receive("timeout", callback)` to abort waiting for our other `receive` hooks
+//  and take action after some period of waiting.
+//
+//
+// ## Socket Hooks
+//
+// Lifecycle events of the multiplexed connection can be hooked into via
+// `socket.onError()` and `socket.onClose()` events, ie:
+//
+//     socket.onError( () => console.log("there was an error with the connection!") )
+//     socket.onClose( () => console.log("the connection dropped") )
+//
+//
+// ## Channel Hooks
+//
+// For each joined channel, you can bind to `onError` and `onClose` events
+// to monitor the channel lifecycle, ie:
+//
+//     channel.onError( () => console.log("there was an error!") )
+//     channel.onClose( () => console.log("the channel has gone away gracefully") )
+//
+// ### onError hooks
+//
+// `onError` hooks are invoked if the socket connection drops, or the channel
+// crashes on the server. In either case, a channel rejoin is attemtped
+// automatically in an exponential backoff manner.
+//
+// ### onClose hooks
+//
+// `onClose` hooks are invoked only in two cases. 1) the channel explicitly
+// closed on the server, or 2). The client explicitly closed, by calling
+// `channel.leave()`
+//
+
+const VSN = "1.0.0"
 const SOCKET_STATES = {connecting: 0, open: 1, closing: 2, closed: 3}
+const DEFAULT_TIMEOUT = 10000
+const CHANNEL_STATES = {
+  closed: "closed",
+  errored: "errored",
+  joined: "joined",
+  joining: "joining",
+}
 const CHANNEL_EVENTS = {
   close: "phx_close",
   error: "phx_error",
@@ -6,66 +101,58 @@ const CHANNEL_EVENTS = {
   reply: "phx_reply",
   leave: "phx_leave"
 }
+const TRANSPORTS = {
+  longpoll: "longpoll",
+  websocket: "websocket"
+}
 
 class Push {
 
   // Initializes the Push
   //
-  // chan - The Channel
-  // event - The event, ie `"phx_join"`
-  // payload - The payload, ie `{user_id: 123}`
-  // mergePush - The optional `Push` to merge hooks from
-  constructor(chan, event, payload, mergePush){
-    this.chan         = chan
+  // channel - The Channel
+  // event - The event, for example `"phx_join"`
+  // payload - The payload, for example `{user_id: 123}`
+  // timeout - The push timeout in milliseconds
+  //
+  constructor(channel, event, payload, timeout){
+    this.channel      = channel
     this.event        = event
     this.payload      = payload || {}
     this.receivedResp = null
-    this.afterHooks   = []
-    this.recHooks     = {}
+    this.timeout      = timeout
+    this.timeoutTimer = null
+    this.recHooks     = []
     this.sent         = false
-    if(mergePush){
-      mergePush.afterHooks.forEach( hook => this.after(hook.ms, hook.callback) )
-      for(var status in mergePush.recHooks){
-        if(mergePush.recHooks.hasOwnProperty(status)){
-          this.receive(status, mergePush.recHooks[status])
-        }
-      }
-    }
   }
 
-  send(){
-    const ref      = this.chan.socket.makeRef()
-    const refEvent = this.chan.replyEventName(ref)
+  resend(timeout){
+    this.timeout = timeout
+    this.cancelRefEvent()
+    this.ref          = null
+    this.refEvent     = null
+    this.receivedResp = null
+    this.sent         = false
+    this.send()
+  }
 
-    this.chan.on(refEvent, payload => {
-      this.receivedResp = payload
-      this.matchReceive(payload)
-      this.chan.off(refEvent)
-      this.cancelAfters()
-    })
-
-    this.startAfters()
+  send(){ if(this.hasReceived("timeout")){ return }
+    this.startTimeout()
     this.sent = true
-    this.chan.socket.push({
-      topic: this.chan.topic,
+    this.channel.socket.push({
+      topic: this.channel.topic,
       event: this.event,
       payload: this.payload,
-      ref: ref
+      ref: this.ref
     })
   }
 
   receive(status, callback){
-    if(this.receivedResp && this.receivedResp.status === status){
+    if(this.hasReceived(status)){
       callback(this.receivedResp.response)
     }
-    this.recHooks[status] = callback
-    return this
-  }
 
-  after(ms, callback){
-    let timer = null
-    if(this.sent){ timer = setTimeout(callback, ms) }
-    this.afterHooks.push({ms: ms, callback: callback, timer: timer})
+    this.recHooks.push({status, callback})
     return this
   }
 
@@ -73,110 +160,181 @@ class Push {
   // private
 
   matchReceive({status, response, ref}){
-    let callback = this.recHooks[status]
-    if(!callback){ return }
-
-    if(this.event === CHANNEL_EVENTS.join){
-      callback(this.chan)
-    } else {
-      callback(response)
-    }
+    this.recHooks.filter( h => h.status === status )
+                 .forEach( h => h.callback(response) )
   }
 
-  cancelAfters(){
-    this.afterHooks.forEach( hook => {
-      clearTimeout(hook.timer)
-      hook.timer = null
-    })
+  cancelRefEvent(){ if(!this.refEvent){ return }
+    this.channel.off(this.refEvent)
   }
 
-  startAfters(){
-    this.afterHooks.map( hook => {
-      if(!hook.timer){
-        hook.timer = setTimeout(() => hook.callback(), hook.ms)
-      }
+  cancelTimeout(){
+    clearTimeout(this.timeoutTimer)
+    this.timeoutTimer = null
+  }
+
+  startTimeout(){ if(this.timeoutTimer){ return }
+    this.ref      = this.channel.socket.makeRef()
+    this.refEvent = this.channel.replyEventName(this.ref)
+
+    this.channel.on(this.refEvent, payload => {
+      this.cancelRefEvent()
+      this.cancelTimeout()
+      this.receivedResp = payload
+      this.matchReceive(payload)
     })
+
+    this.timeoutTimer = setTimeout(() => {
+      this.trigger("timeout", {})
+    }, this.timeout)
+  }
+
+  hasReceived(status){
+    return this.receivedResp && this.receivedResp.status === status
+  }
+
+  trigger(status, response){
+    this.channel.trigger(this.refEvent, {status, response})
   }
 }
 
 export class Channel {
-  constructor(topic, message, callback, socket) {
-    this.topic      = topic
-    this.message    = message
-    this.callback   = callback
-    this.socket     = socket
-    this.bindings   = []
-    this.afterHooks = []
-    this.recHooks   = {}
-    this.joinPush   = new Push(this, CHANNEL_EVENTS.join, this.message)
+  constructor(topic, params, socket) {
+    this.state       = CHANNEL_STATES.closed
+    this.topic       = topic
+    this.params      = params || {}
+    this.socket      = socket
+    this.bindings    = []
+    this.timeout     = this.socket.timeout
+    this.joinedOnce  = false
+    this.joinPush    = new Push(this, CHANNEL_EVENTS.join, this.params, this.timeout)
+    this.pushBuffer  = []
+    this.rejoinTimer  = new Timer(
+      () => this.rejoinUntilConnected(),
+      this.socket.reconnectAfterMs
+    )
+    this.joinPush.receive("ok", () => {
+      this.state = CHANNEL_STATES.joined
+      this.rejoinTimer.reset()
+      this.pushBuffer.forEach( pushEvent => pushEvent.send() )
+      this.pushBuffer = []
+    })
+    this.onClose( () => {
+      this.socket.log("channel", `close ${this.topic}`)
+      this.state = CHANNEL_STATES.closed
+      this.socket.remove(this)
+    })
+    this.onError( reason => {
+      this.socket.log("channel", `error ${this.topic}`, reason)
+      this.state = CHANNEL_STATES.errored
+      this.rejoinTimer.setTimeout()
+    })
+    this.joinPush.receive("timeout", () => {
+      if(this.state !== CHANNEL_STATES.joining){ return }
 
-    this.reset()
+      this.socket.log("channel", `timeout ${this.topic}`, this.joinPush.timeout)
+      this.state = CHANNEL_STATES.errored
+      this.rejoinTimer.setTimeout()
+    })
+    this.on(CHANNEL_EVENTS.reply, (payload, ref) => {
+      this.trigger(this.replyEventName(ref), payload)
+    })
   }
 
-  after(ms, callback){
-    this.joinPush.after(ms, callback)
-    return this
+  rejoinUntilConnected(){
+    this.rejoinTimer.setTimeout()
+    if(this.socket.isConnected()){
+      this.rejoin()
+    }
   }
 
-  receive(status, callback){
-    this.joinPush.receive(status, callback)
-    return this
-  }
-
-  rejoin(){
-    this.reset()
-    this.joinPush.send()
+  join(timeout = this.timeout){
+    if(this.joinedOnce){
+      throw(`tried to join multiple times. 'join' can only be called a single time per channel instance`)
+    } else {
+      this.joinedOnce = true
+    }
+    this.rejoin(timeout)
+    return this.joinPush
   }
 
   onClose(callback){ this.on(CHANNEL_EVENTS.close, callback) }
 
   onError(callback){
-    this.on(CHANNEL_EVENTS.error, reason => {
-      callback(reason)
-      this.trigger(CHANNEL_EVENTS.close, "error")
-    })
-  }
-
-  reset(){
-    this.bindings = []
-    let newJoinPush = new Push(this, CHANNEL_EVENTS.join, this.message, this.joinPush)
-    this.joinPush = newJoinPush
-    this.onError( reason => {
-      setTimeout(() => this.rejoin(), this.socket.reconnectAfterMs)
-    })
-    this.on(CHANNEL_EVENTS.reply, payload => {
-      this.trigger(this.replyEventName(payload.ref), payload)
-    })
+    this.on(CHANNEL_EVENTS.error, reason => callback(reason) )
   }
 
   on(event, callback){ this.bindings.push({event, callback}) }
 
-  isMember(topic){ return this.topic === topic }
-
   off(event){ this.bindings = this.bindings.filter( bind => bind.event !== event ) }
 
-  trigger(triggerEvent, msg){
-    this.bindings.filter( bind => bind.event === triggerEvent )
-                 .map( bind => bind.callback(msg) )
-  }
+  canPush(){ return this.socket.isConnected() && this.state === CHANNEL_STATES.joined }
 
-  push(event, payload){
-    let pushEvent = new Push(this, event, payload)
-    pushEvent.send()
+  push(event, payload, timeout = this.timeout){
+    if(!this.joinedOnce){
+      throw(`tried to push '${event}' to '${this.topic}' before joining. Use channel.join() before pushing events`)
+    }
+    let pushEvent = new Push(this, event, payload, timeout)
+    if(this.canPush()){
+      pushEvent.send()
+    } else {
+      pushEvent.startTimeout()
+      this.pushBuffer.push(pushEvent)
+    }
 
     return pushEvent
   }
 
-  replyEventName(ref){ return `chan_reply_${ref}` }
+  // Leaves the channel
+  //
+  // Unsubscribes from server events, and
+  // instructs channel to terminate on server
+  //
+  // Triggers onClose() hooks
+  //
+  // To receive leave acknowledgements, use the a `receive`
+  // hook to bind to the server ack, ie:
+  //
+  //     channel.leave().receive("ok", () => alert("left!") )
+  //
+  leave(timeout = this.timeout){
+    let onClose = () => {
+      this.socket.log("channel", `leave ${this.topic}`)
+      this.trigger(CHANNEL_EVENTS.close, "leave")
+    }
+    let leavePush = new Push(this, CHANNEL_EVENTS.leave, {}, timeout)
+    leavePush.receive("ok", () => onClose() )
+             .receive("timeout", () => onClose() )
+    leavePush.send()
+    if(!this.canPush()){ leavePush.trigger("ok", {}) }
 
-  leave(){
-    return this.push(CHANNEL_EVENTS.leave).receive("ok", () => {
-      this.socket.leave(this)
-      chan.reset()
-    })
+    return leavePush
   }
-}
 
+  // Overridable message hook
+  //
+  // Receives all events for specialized message handling
+  onMessage(event, payload, ref){}
+
+  // private
+
+  isMember(topic){ return this.topic === topic }
+
+  sendJoin(timeout){
+    this.state = CHANNEL_STATES.joining
+    this.joinPush.resend(timeout)
+  }
+
+  rejoin(timeout = this.timeout){ this.sendJoin(timeout) }
+
+  trigger(triggerEvent, payload, ref){
+    this.onMessage(triggerEvent, payload, ref)
+    this.bindings.filter( bind => bind.event === triggerEvent )
+                 .map( bind => bind.callback(payload, ref) )
+  }
+
+  replyEventName(ref){ return `chan_reply_${ref}` }
+}
 
 export class Socket {
 
@@ -186,42 +344,57 @@ export class Socket {
   //                                               "wss://example.com"
   //                                               "/ws" (inherited host & protocol)
   // opts - Optional configuration
-  //   transport - The Websocket Transport, ie WebSocket, Phoenix.LongPoller.
-  //               Defaults to WebSocket with automatic LongPoller fallback.
+  //   transport - The Websocket Transport, for example WebSocket or Phoenix.LongPoll.
+  //               Defaults to WebSocket with automatic LongPoll fallback.
+  //   timeout - The default timeout in milliseconds to trigger push timeouts.
+  //             Defaults `DEFAULT_TIMEOUT`
   //   heartbeatIntervalMs - The millisec interval to send a heartbeat message
-  //   reconnectAfterMs - The millisec interval to reconnect after connection loss
+  //   reconnectAfterMs - The optional function that returns the millsec
+  //                      reconnect interval. Defaults to stepped backoff of:
+  //
+  //     function(tries){
+  //       return [1000, 5000, 10000][tries - 1] || 10000
+  //     }
+  //
   //   logger - The optional function for specialized logging, ie:
-  //            `logger: function(msg){ console.log(msg) }`
-  //   longpoller_timeout - The maximum timeout of a long poll AJAX request.
+  //     `logger: (kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }
+  //
+  //   longpollerTimeout - The maximum timeout of a long poll AJAX request.
   //                        Defaults to 20s (double the server long poll timer).
+  //
+  //   params - The optional params to pass when connecting
   //
   // For IE8 support use an ES5-shim (https://github.com/es-shims/es5-shim)
   //
   constructor(endPoint, opts = {}){
-    this.states               = SOCKET_STATES
     this.stateChangeCallbacks = {open: [], close: [], error: [], message: []}
-    this.flushEveryMs         = 50
-    this.reconnectTimer       = null
     this.channels             = []
     this.sendBuffer           = []
     this.ref                  = 0
-    this.transport            = opts.transport || window.WebSocket || LongPoller
+    this.timeout              = opts.timeout || DEFAULT_TIMEOUT
+    this.transport            = opts.transport || window.WebSocket || LongPoll
     this.heartbeatIntervalMs  = opts.heartbeatIntervalMs || 30000
-    this.reconnectAfterMs     = opts.reconnectAfterMs || 5000
+    this.reconnectAfterMs     = opts.reconnectAfterMs || function(tries){
+      return [1000, 2000, 5000, 10000][tries - 1] || 10000
+    }
     this.logger               = opts.logger || function(){} // noop
-    this.longpoller_timeout   = opts.longpoller_timeout || 20000
-    this.endPoint             = this.expandEndpoint(endPoint)
-
-    this.resetBufferTimer()
+    this.longpollerTimeout    = opts.longpollerTimeout || 20000
+    this.params               = opts.params || {}
+    this.endPoint             = `${endPoint}/${TRANSPORTS.websocket}`
+    this.reconnectTimer       = new Timer(() => {
+      this.disconnect(() => this.connect())
+    }, this.reconnectAfterMs)
   }
 
   protocol(){ return location.protocol.match(/^https/) ? "wss" : "ws" }
 
-  expandEndpoint(endPoint){
-    if(endPoint.charAt(0) !== "/"){ return endPoint }
-    if(endPoint.charAt(1) === "/"){ return `${this.protocol()}:${endPoint}` }
+  endPointURL(){
+    let uri = Ajax.appendParams(
+      Ajax.appendParams(this.endPoint, this.params), {vsn: VSN})
+    if(uri.charAt(0) !== "/"){ return uri }
+    if(uri.charAt(1) === "/"){ return `${this.protocol()}:${uri}` }
 
-    return `${this.protocol()}://${location.host}${endPoint}`
+    return `${this.protocol()}://${location.host}${uri}`
   }
 
   disconnect(callback, code, reason){
@@ -233,30 +406,30 @@ export class Socket {
     callback && callback()
   }
 
-  connect(){
-    this.disconnect(() => {
-      this.conn = new this.transport(this.endPoint)
-      this.conn.timeout   = this.longpoller_timeout
-      this.conn.onopen    = () => this.onConnOpen()
-      this.conn.onerror   = error => this.onConnError(error)
-      this.conn.onmessage = event => this.onConnMessage(event)
-      this.conn.onclose   = event => this.onConnClose(event)
-    })
-  }
+  // params - The params to send when connecting, for example `{user_id: userToken}`
+  connect(params){
+    if(params){
+      console && console.log("passing params to connect is deprecated. Instead pass :params to the Socket constructor")
+      this.params = params
+    }
+    if(this.conn){ return }
 
-  resetBufferTimer(){
-    clearTimeout(this.sendBufferTimer)
-    this.sendBufferTimer = setTimeout(() => this.flushSendBuffer(), this.flushEveryMs)
+    this.conn = new this.transport(this.endPointURL())
+    this.conn.timeout   = this.longpollerTimeout
+    this.conn.onopen    = () => this.onConnOpen()
+    this.conn.onerror   = error => this.onConnError(error)
+    this.conn.onmessage = event => this.onConnMessage(event)
+    this.conn.onclose   = event => this.onConnClose(event)
   }
 
   // Logs the message. Override `this.logger` for specialized logging. noops by default
-  log(msg){ this.logger(msg) }
+  log(kind, msg, data){ this.logger(kind, msg, data) }
 
   // Registers callbacks for connection state change events
   //
   // Examples
   //
-  //    socket.onError function(error){ alert("An error occurred") }
+  //    socket.onError(function(error){ alert("An error occurred") })
   //
   onOpen     (callback){ this.stateChangeCallbacks.open.push(callback) }
   onClose    (callback){ this.stateChangeCallbacks.close.push(callback) }
@@ -264,56 +437,59 @@ export class Socket {
   onMessage  (callback){ this.stateChangeCallbacks.message.push(callback) }
 
   onConnOpen(){
-    clearInterval(this.reconnectTimer)
+    this.log("transport", `connected to ${this.endPointURL()}`, this.transport.prototype)
+    this.flushSendBuffer()
+    this.reconnectTimer.reset()
     if(!this.conn.skipHeartbeat){
       clearInterval(this.heartbeatTimer)
       this.heartbeatTimer = setInterval(() => this.sendHeartbeat(), this.heartbeatIntervalMs)
     }
-    this.rejoinAll()
     this.stateChangeCallbacks.open.forEach( callback => callback() )
   }
 
   onConnClose(event){
-    this.log("WS close:")
-    this.log(event)
-    clearInterval(this.reconnectTimer)
+    this.log("transport", "close", event)
+    this.triggerChanError()
     clearInterval(this.heartbeatTimer)
-    this.reconnectTimer = setInterval(() => this.connect(), this.reconnectAfterMs)
+    this.reconnectTimer.setTimeout()
     this.stateChangeCallbacks.close.forEach( callback => callback(event) )
   }
 
   onConnError(error){
-    this.log("WS error:")
-    this.log(error)
+    this.log("transport", error)
+    this.triggerChanError()
     this.stateChangeCallbacks.error.forEach( callback => callback(error) )
+  }
+
+  triggerChanError(){
+    this.channels.forEach( channel => channel.trigger(CHANNEL_EVENTS.error) )
   }
 
   connectionState(){
     switch(this.conn && this.conn.readyState){
-      case this.states.connecting: return "connecting"
-      case this.states.open:       return "open"
-      case this.states.closing:    return "closing"
-      default:                     return "closed"
+      case SOCKET_STATES.connecting: return "connecting"
+      case SOCKET_STATES.open:       return "open"
+      case SOCKET_STATES.closing:    return "closing"
+      default:                       return "closed"
     }
   }
 
   isConnected(){ return this.connectionState() === "open" }
 
-  rejoinAll(){ this.channels.forEach( chan => chan.rejoin() ) }
+  remove(channel){
+    this.channels = this.channels.filter( c => !c.isMember(channel.topic) )
+  }
 
-  join(topic, message, callback){
-    let chan = new Channel(topic, message, callback, this)
+  channel(topic, chanParams = {}){
+    let chan = new Channel(topic, chanParams, this)
     this.channels.push(chan)
-    if(this.isConnected()){ chan.rejoin() }
     return chan
   }
 
-  leave(chan){
-    this.channels = this.channels.filter( c => !c.isMember(chan.topic) )
-  }
-
   push(data){
+    let {topic, event, payload, ref} = data
     let callback = () => this.conn.send(JSON.stringify(data))
+    this.log("push", `${topic} ${event} (${ref})`, payload)
     if(this.isConnected()){
       callback()
     }
@@ -330,7 +506,7 @@ export class Socket {
     return this.ref.toString()
   }
 
-  sendHeartbeat(){
+  sendHeartbeat(){ if(!this.isConnected()){ return }
     this.push({topic: "phoenix", event: "heartbeat", payload: {}, ref: this.makeRef()})
   }
 
@@ -339,53 +515,49 @@ export class Socket {
       this.sendBuffer.forEach( callback => callback() )
       this.sendBuffer = []
     }
-    this.resetBufferTimer()
   }
 
   onConnMessage(rawMessage){
-    this.log("message received:")
-    this.log(rawMessage)
-    let {topic, event, payload} = JSON.parse(rawMessage.data)
-    this.channels.filter( chan => chan.isMember(topic) )
-                 .forEach( chan => chan.trigger(event, payload) )
-    this.stateChangeCallbacks.message.forEach( callback => {
-      callback(topic, event, payload)
-    })
+    let msg = JSON.parse(rawMessage.data)
+    let {topic, event, payload, ref} = msg
+    this.log("receive", `${payload.status || ""} ${topic} ${event} ${ref && "(" + ref + ")" || ""}`, payload)
+    this.channels.filter( channel => channel.isMember(topic) )
+                 .forEach( channel => channel.trigger(event, payload, ref) )
+    this.stateChangeCallbacks.message.forEach( callback => callback(msg) )
   }
 }
 
 
-export class LongPoller {
+export class LongPoll {
 
   constructor(endPoint){
-    this.retryInMs       = 5000
     this.endPoint        = null
     this.token           = null
-    this.sig             = null
     this.skipHeartbeat   = true
     this.onopen          = function(){} // noop
     this.onerror         = function(){} // noop
     this.onmessage       = function(){} // noop
     this.onclose         = function(){} // noop
-    this.states          = SOCKET_STATES
-    this.upgradeEndpoint = this.normalizeEndpoint(endPoint)
-    this.pollEndpoint    = this.upgradeEndpoint + (/\/$/.test(endPoint) ? "poll" : "/poll")
-    this.readyState      = this.states.connecting
+    this.pollEndpoint    = this.normalizeEndpoint(endPoint)
+    this.readyState      = SOCKET_STATES.connecting
 
     this.poll()
   }
 
   normalizeEndpoint(endPoint){
-    return endPoint.replace("ws://", "http://").replace("wss://", "https://")
+    return(endPoint
+      .replace("ws://", "http://")
+      .replace("wss://", "https://")
+      .replace(new RegExp("(.*)\/" + TRANSPORTS.websocket), "$1/" + TRANSPORTS.longpoll))
   }
 
   endpointURL(){
-    return this.pollEndpoint + `?token=${encodeURIComponent(this.token)}&sig=${encodeURIComponent(this.sig)}`
+    return Ajax.appendParams(this.pollEndpoint, {token: this.token})
   }
 
   closeAndRetry(){
     this.close()
-    this.readyState = this.states.connecting
+    this.readyState = SOCKET_STATES.connecting
   }
 
   ontimeout(){
@@ -394,13 +566,12 @@ export class LongPoller {
   }
 
   poll(){
-    if(!(this.readyState === this.states.open || this.readyState === this.states.connecting)){ return }
+    if(!(this.readyState === SOCKET_STATES.open || this.readyState === SOCKET_STATES.connecting)){ return }
 
     Ajax.request("GET", this.endpointURL(), "application/json", null, this.timeout, this.ontimeout.bind(this), (resp) => {
       if(resp){
-        var {status, token, sig, messages} = resp
+        var {status, token, messages} = resp
         this.token = token
-        this.sig = sig
       } else{
         var status = 0
       }
@@ -414,7 +585,7 @@ export class LongPoller {
           this.poll()
           break
         case 410:
-          this.readyState = this.states.open
+          this.readyState = SOCKET_STATES.open
           this.onopen()
           this.poll()
           break
@@ -438,7 +609,7 @@ export class LongPoller {
   }
 
   close(code, reason){
-    this.readyState = this.states.closed
+    this.readyState = SOCKET_STATES.closed
     this.onclose()
   }
 }
@@ -494,6 +665,65 @@ export class Ajax {
              JSON.parse(resp) :
              null
   }
+
+  static serialize(obj, parentKey){
+    let queryStr = [];
+    for(var key in obj){ if(!obj.hasOwnProperty(key)){ continue }
+      let paramKey = parentKey ? `${parentKey}[${key}]` : key
+      let paramVal = obj[key]
+      if(typeof paramVal === "object"){
+        queryStr.push(this.serialize(paramVal, paramKey))
+      } else {
+        queryStr.push(encodeURIComponent(paramKey) + "=" + encodeURIComponent(paramVal))
+      }
+    }
+    return queryStr.join("&")
+  }
+
+  static appendParams(url, params){
+    if(Object.keys(params).length === 0){ return url }
+
+    let prefix = url.match(/\?/) ? "&" : "?"
+    return `${url}${prefix}${this.serialize(params)}`
+  }
 }
 
 Ajax.states = {complete: 4}
+
+
+// Creates a timer that accepts a `timerCalc` function to perform
+// calculated timeout retries, such as exponential backoff.
+//
+// ## Examples
+//
+//    let reconnectTimer = new Timer(() => this.connect(), function(tries){
+//      return [1000, 5000, 10000][tries - 1] || 10000
+//    })
+//    reconnectTimer.setTimeout() // fires after 1000
+//    reconnectTimer.setTimeout() // fires after 5000
+//    reconnectTimer.reset()
+//    reconnectTimer.setTimeout() // fires after 1000
+//
+class Timer {
+  constructor(callback, timerCalc){
+    this.callback  = callback
+    this.timerCalc = timerCalc
+    this.timer     = null
+    this.tries     = 0
+  }
+
+  reset(){
+    this.tries = 0
+    clearTimeout(this.timer)
+  }
+
+  // Cancels any previous setTimeout and schedules callback
+  setTimeout(){
+    clearTimeout(this.timer)
+
+    this.timer = setTimeout(() => {
+      this.tries = this.tries + 1
+      this.callback()
+    }, this.timerCalc(this.tries + 1))
+  }
+}


### PR DESCRIPTION
Phoenix seems to have removed `Socket.join => Channel` and changed their `join` behavior since the first implementation of _ember-phoenix-adapter_.

I adapted to this change, copied the `phoenix.js` file from the current version of Phoenix and removed some minor deprecations from the adapter.
